### PR TITLE
Z_virus optimization (To fix the lag)

### DIFF
--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -364,9 +364,15 @@
 
 /datum/disease/z_virus/stage_act()
 	..()
-	if(istype(affected_mob, /mob/living/carbon/human/zombie) && !src.carrier)
+
+	if(istype(affected_mob, /mob/living/carbon/human/zombie)) //Possible fix to prevent processing of stage effects (specifically stage 5) after mob has zombified.
+		if(!src.carrier)
+			src.carrier = 1
+		return
+	/*if(istype(affected_mob, /mob/living/carbon/human/zombie) && !src.carrier)
 		src.carrier = 1
 		return
+	*/
 /*	switch(stage)
 		if(1)
 			if (prob(8))

--- a/code/modules/surgery/appendectomy.dm
+++ b/code/modules/surgery/appendectomy.dm
@@ -24,8 +24,8 @@
 		user.visible_message("<span class='notice'>[user] successfully removes [target]'s appendix!</span>")
 		A.loc = get_turf(target)
 		target.internal_organs -= A
-		for(var/datum/disease/appendicitis in target.viruses)
-			appendicitis.cure()
+		for(var/datum/disease/appendicitis/B in target.viruses)
+			B.cure()
 	else
 		user.visible_message("<span class='notice'>[user] can't find an appendix in [target]!</span>")
 	return 1


### PR DESCRIPTION
Changed Z_virus's stage_act() logic to prevent processing of disease stages if the user is already a zombie. Hopefully resolves massive lag caused by zombies.