### PR TITLE
Stage 1 of Atmos Pipe Revisions - Code cleanup

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -17,6 +17,8 @@ obj/machinery/atmospherics
 	power_channel = ENVIRON
 	var/nodealert = 0
 	var/can_unwrench = 0
+	var/list/node = list(1=null, 2=null, 3=null, 4=null)
+	var/nodecount = 0
 
 
 
@@ -55,6 +57,12 @@ obj/machinery/atmospherics/proc/return_network_air(datum/network/reference)
 	// Is permitted to return null
 
 obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
+
+obj/machinery/atmospherics/proc/normalize_dir()
+	if(dir==3)
+		dir = 1
+	else if(dir==12)
+		dir = 4
 
 obj/machinery/atmospherics/update_icon()
 	color = pipe_color

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -2,12 +2,10 @@ obj/machinery/atmospherics/binary
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
 	use_power = 1
+	nodecount = 2
 
 	var/datum/gas_mixture/air1
 	var/datum/gas_mixture/air2
-
-	var/obj/machinery/atmospherics/node1
-	var/obj/machinery/atmospherics/node2
 
 	var/datum/pipe_network/network1
 	var/datum/pipe_network/network2
@@ -31,10 +29,10 @@ obj/machinery/atmospherics/binary
 
 // Housekeeping and pipe network stuff below
 	network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-		if(reference == node1)
+		if(reference == NODE_1)
 			network1 = new_network
 
-		else if(reference == node2)
+		else if(reference == NODE_2)
 			network2 = new_network
 
 		if(new_network.normal_members.Find(src))
@@ -47,15 +45,16 @@ obj/machinery/atmospherics/binary
 	Destroy()
 		loc = null
 
-		if(node1)
-			node1.disconnect(src)
+		if(NODE_1)
+			var/obj/machinery/atmospherics/A = NODE_1
+			A.disconnect(src)
 			del(network1)
-		if(node2)
-			node2.disconnect(src)
+			NODE_1 = null
+		if(NODE_2)
+			var/obj/machinery/atmospherics/A = NODE_2
+			A.disconnect(src)
 			del(network2)
-
-		node1 = null
-		node2 = null
+			NODE_2 = null
 
 		..()
 
@@ -67,35 +66,35 @@ obj/machinery/atmospherics/binary
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node1 = target
+				NODE_1 = target
 				break
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node2 = target
+				NODE_2 = target
 				break
 
 		update_icon()
 
 	build_network()
-		if(!network1 && node1)
+		if(!network1 && NODE_1)
 			network1 = new /datum/pipe_network()
 			network1.normal_members += src
-			network1.build_network(node1, src)
+			network1.build_network(NODE_1, src)
 
-		if(!network2 && node2)
+		if(!network2 && NODE_2)
 			network2 = new /datum/pipe_network()
 			network2.normal_members += src
-			network2.build_network(node2, src)
+			network2.build_network(NODE_2, src)
 
 
 	return_network(obj/machinery/atmospherics/reference)
 		build_network()
 
-		if(reference==node1)
+		if(reference==NODE_1)
 			return network1
 
-		if(reference==node2)
+		if(reference==NODE_2)
 			return network2
 
 		return null
@@ -119,12 +118,12 @@ obj/machinery/atmospherics/binary
 		return results
 
 	disconnect(obj/machinery/atmospherics/reference)
-		if(reference==node1)
+		if(reference==NODE_1)
 			del(network1)
-			node1 = null
+			NODE_1 = null
 
-		else if(reference==node2)
+		else if(reference==NODE_2)
 			del(network2)
-			node2 = null
+			NODE_2 = null
 
 		return null

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -19,12 +19,12 @@ obj/machinery/atmospherics/binary/passive_gate
 	update_icon()
 		if(stat & NOPOWER)
 			icon_state = "intact_off"
-		else if(node1 && node2)
+		else if(NODE_1 && NODE_2)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
-			if(node1)
+			if(NODE_1)
 				icon_state = "exposed_1_off"
-			else if(node2)
+			else if(NODE_2)
 				icon_state = "exposed_2_off"
 			else
 				icon_state = "exposed_3_off"

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -35,12 +35,12 @@ obj/machinery/atmospherics/binary/pump
 	update_icon()
 		if(stat & NOPOWER)
 			icon_state = "intact_off"
-		else if(node1 && node2)
+		else if(NODE_1 && NODE_2)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
-			if(node1)
+			if(NODE_1)
 				icon_state = "exposed_1_off"
-			else if(node2)
+			else if(NODE_2)
 				icon_state = "exposed_2_off"
 			else
 				icon_state = "exposed_3_off"

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -35,12 +35,12 @@ obj/machinery/atmospherics/binary/volume_pump
 	update_icon()
 		if(stat & NOPOWER)
 			icon_state = "intact_off"
-		else if(node1 && node2)
+		else if(NODE_1 && NODE_2)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
-			if(node1)
+			if(NODE_1)
 				icon_state = "exposed_1_off"
-			else if(node2)
+			else if(NODE_2)
 				icon_state = "exposed_2_off"
 			else
 				icon_state = "exposed_3_off"

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -7,12 +7,11 @@
 
 	dir = SOUTH
 	initialize_directions = SOUTH
+	nodecount = 1
 
 	can_unwrench = 1
 
 	var/obj/machinery/portable_atmospherics/connected_device
-
-	var/obj/machinery/atmospherics/node
 
 	var/datum/pipe_network/network
 
@@ -26,9 +25,9 @@
 		..()
 
 	update_icon()
-		if(node)
+		if(node[1])
 			icon_state = "[level == 1 && istype(loc, /turf/simulated) ? "h" : "" ]intact"
-			dir = get_dir(src, node)
+			dir = get_dir(src, node[1])
 		else
 			icon_state = "exposed"
 		color = pipe_color
@@ -36,9 +35,9 @@
 		return
 
 	hide(var/i) //to make the little pipe section invisible, the icon changes.
-		if(node)
+		if(node[1])
 			icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]intact"
-			dir = get_dir(src, node)
+			dir = get_dir(src, node[1])
 		else
 			icon_state = "exposed"
 
@@ -55,7 +54,7 @@
 
 // Housekeeping and pipe network stuff below
 	network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-		if(reference == node)
+		if(reference == node[1])
 			network = new_network
 
 		if(new_network.normal_members.Find(src))
@@ -69,8 +68,9 @@
 		if(connected_device)
 			connected_device.disconnect()
 
-		if(node)
-			node.disconnect(src)
+		if(node[1])
+			var/obj/machinery/atmospherics/A = node[1]
+			A.disconnect(src)
 			del(network)
 
 		node = null
@@ -84,22 +84,22 @@
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node = target
+				node[1] = target
 				break
 
 		update_icon()
 
 	build_network()
-		if(!network && node)
+		if(!network && NODE_1)
 			network = new /datum/pipe_network()
 			network.normal_members += src
-			network.build_network(node, src)
+			network.build_network(NODE_1, src)
 
 
 	return_network(obj/machinery/atmospherics/reference)
 		build_network()
 
-		if(reference==node)
+		if(reference==node[1])
 			return network
 
 		if(reference==connected_device)
@@ -122,9 +122,9 @@
 		return results
 
 	disconnect(obj/machinery/atmospherics/reference)
-		if(reference==node)
+		if(reference==node[1])
 			del(network)
-			node = null
+			node[1] = null
 
 		return null
 

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -43,7 +43,7 @@ Filter types:
 	update_icon()
 		if(stat & NOPOWER)
 			icon_state = "intact_off"
-		else if(node2 && node3 && node1)
+		else if(NODE_2 && NODE_3 && NODE_1)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
 			icon_state = "intact_off"

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -20,7 +20,7 @@ obj/machinery/atmospherics/trinary/mixer
 	update_icon()
 		if(stat & NOPOWER)
 			icon_state = "intact_off"
-		else if(node2 && node3 && node1)
+		else if(NODE_2 && NODE_3 && NODE_1)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
 			icon_state = "intact_off"

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -2,14 +2,11 @@ obj/machinery/atmospherics/trinary
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = 1
+	nodecount = 3
 
 	var/datum/gas_mixture/air1
 	var/datum/gas_mixture/air2
 	var/datum/gas_mixture/air3
-
-	var/obj/machinery/atmospherics/node1
-	var/obj/machinery/atmospherics/node2
-	var/obj/machinery/atmospherics/node3
 
 	var/datum/pipe_network/network1
 	var/datum/pipe_network/network2
@@ -36,13 +33,13 @@ obj/machinery/atmospherics/trinary
 
 // Housekeeping and pipe network stuff below
 	network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-		if(reference == node1)
+		if(reference == NODE_1)
 			network1 = new_network
 
-		else if(reference == node2)
+		else if(reference == NODE_2)
 			network2 = new_network
 
-		else if (reference == node3)
+		else if (reference == NODE_3)
 			network3 = new_network
 
 		if(new_network.normal_members.Find(src))
@@ -53,19 +50,22 @@ obj/machinery/atmospherics/trinary
 		return null
 
 	Destroy()
-		if(node1)
-			node1.disconnect(src)
+		if(NODE_1)
+			var/obj/machinery/atmospherics/A = NODE_1
+			A.disconnect(src)
 			del(network1)
-		if(node2)
-			node2.disconnect(src)
+		if(NODE_2)
+			var/obj/machinery/atmospherics/A = NODE_2
+			A.disconnect(src)
 			del(network2)
-		if(node3)
-			node3.disconnect(src)
+		if(NODE_3)
+			var/obj/machinery/atmospherics/A = NODE_3
+			A.disconnect(src)
 			del(network3)
 
-		node1 = null
-		node2 = null
-		node3 = null
+		NODE_1 = null
+		NODE_2 = null
+		NODE_3 = null
 
 		..()
 
@@ -78,48 +78,48 @@ obj/machinery/atmospherics/trinary
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node1 = target
+				NODE_1 = target
 				break
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node2 = target
+				NODE_2 = target
 				break
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node3 = target
+				NODE_3 = target
 				break
 
 		update_icon()
 
 	build_network()
-		if(!network1 && node1)
+		if(!network1 && NODE_1)
 			network1 = new /datum/pipe_network()
 			network1.normal_members += src
-			network1.build_network(node1, src)
+			network1.build_network(NODE_1, src)
 
-		if(!network2 && node2)
+		if(!network2 && NODE_2)
 			network2 = new /datum/pipe_network()
 			network2.normal_members += src
-			network2.build_network(node2, src)
+			network2.build_network(NODE_2, src)
 
-		if(!network3 && node3)
+		if(!network3 && NODE_3)
 			network3 = new /datum/pipe_network()
 			network3.normal_members += src
-			network3.build_network(node3, src)
+			network3.build_network(NODE_3, src)
 
 
 	return_network(obj/machinery/atmospherics/reference)
 		build_network()
 
-		if(reference==node1)
+		if(reference==NODE_1)
 			return network1
 
-		if(reference==node2)
+		if(reference==NODE_2)
 			return network2
 
-		if(reference==node3)
+		if(reference==NODE_3)
 			return network3
 
 		return null
@@ -147,16 +147,16 @@ obj/machinery/atmospherics/trinary
 		return results
 
 	disconnect(obj/machinery/atmospherics/reference)
-		if(reference==node1)
+		if(reference==NODE_1)
 			del(network1)
-			node1 = null
+			NODE_1 = null
 
-		else if(reference==node2)
+		else if(reference==NODE_2)
 			del(network2)
-			node2 = null
+			NODE_2 = null
 
-		else if(reference==node3)
+		else if(reference==NODE_3)
 			del(network3)
-			node3 = null
+			NODE_3 = null
 
 		return null

--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -13,7 +13,7 @@
 	var/current_heat_capacity = 50000 //totally random
 
 	update_icon()
-		if(node)
+		if(NODE_1)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
 			icon_state = "exposed"

--- a/code/ATMOSPHERICS/components/unary/generator_input.dm
+++ b/code/ATMOSPHERICS/components/unary/generator_input.dm
@@ -9,7 +9,7 @@
 	var/update_cycle
 
 	update_icon()
-		if(node)
+		if(NODE_1)
 			icon_state = "intact"
 		else
 			icon_state = "exposed"

--- a/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
@@ -13,7 +13,7 @@
 	var/update_cycle
 
 	update_icon()
-		if(node)
+		if(NODE_1)
 			icon_state = "intact"
 		else
 			icon_state = "exposed"

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -15,7 +15,7 @@
 	var/current_heat_capacity = 50000 //totally random
 
 	update_icon()
-		if(node)
+		if(NODE_1)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
 			icon_state = "exposed"

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -18,7 +18,7 @@
 	level = 1
 
 	update_icon()
-		if(node)
+		if(NODE_1)
 			if(on && !(stat & NOPOWER))
 				icon_state = "[level == 1 && istype(loc, /turf/simulated) ? "h" : "" ]on"
 			else
@@ -140,7 +140,7 @@
 		update_icon()
 
 	hide(var/i) //to make the little pipe section invisible, the icon changes.
-		if(node)
+		if(NODE_1)
 			if(on)
 				icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]on"
 			else

--- a/code/ATMOSPHERICS/components/unary/oxygen_generator.dm
+++ b/code/ATMOSPHERICS/components/unary/oxygen_generator.dm
@@ -14,7 +14,7 @@ obj/machinery/atmospherics/unary/oxygen_generator
 	var/oxygen_content = 10
 
 	update_icon()
-		if(node)
+		if(NODE_1)
 			icon_state = "intact_[on?("on"):("off")]"
 		else
 			icon_state = "exposed_off"

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -2,10 +2,9 @@
 	dir = SOUTH
 	initialize_directions = SOUTH
 	layer = TURF_LAYER+0.1
+	nodecount = 1
 
 	var/datum/gas_mixture/air_contents
-
-	var/obj/machinery/atmospherics/node
 
 	var/datum/pipe_network/network
 
@@ -18,7 +17,7 @@
 
 // Housekeeping and pipe network stuff below
 	network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-		if(reference == node)
+		if(reference == NODE_1)
 			network = new_network
 
 		if(new_network.normal_members.Find(src))
@@ -29,11 +28,12 @@
 		return null
 
 	Destroy()
-		if(node)
-			node.disconnect(src)
+		if(NODE_1)
+			var/obj/machinery/atmospherics/A = NODE_1
+			A.disconnect(src)
 			del(network)
 
-		node = null
+		NODE_1 = null
 
 		..()
 
@@ -45,7 +45,7 @@
 
 		for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
 			if(target.initialize_directions & get_dir(target,src))
-				node = target
+				NODE_1 = target
 				if(!infiniteloop)
 					target.initialize(1)
 				break
@@ -56,22 +56,22 @@
 	default_change_direction_wrench(mob/user, obj/item/weapon/wrench/W)
 		if(..())
 			initialize_directions = dir
-			if(node)
-				disconnect(node)
+			if(NODE_1)
+				disconnect(NODE_1)
 			initialize()
 			. = 1
 
 	build_network()
-		if(!network && node)
+		if(!network && NODE_1)
 			network = new /datum/pipe_network()
 			network.normal_members += src
-			network.build_network(node, src)
+			network.build_network(NODE_1, src)
 
 
 	return_network(obj/machinery/atmospherics/reference)
 		build_network()
 
-		if(reference==node)
+		if(reference==NODE_1)
 			return network
 
 		return null
@@ -91,8 +91,8 @@
 		return results
 
 	disconnect(obj/machinery/atmospherics/reference)
-		if(reference==node)
-			node = null
+		if(reference==NODE_1)
+			NODE_1 = null
 			reference.disconnect(src)
 			del(network)
 

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -83,7 +83,7 @@
 		..()
 		if(stat & (NOPOWER|BROKEN))
 			return
-		if (!node)
+		if (!NODE_1)
 			on = 0
 		//broadcast_status() // from now air alarm/control computer should request update purposely --rastaf0
 		if(!on)
@@ -265,7 +265,7 @@
 		if(welded)
 			icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]weld"
 			return
-		if(on&&node)
+		if(on&&NODE_1)
 			if(pump_direction)
 				icon_state = "[i == 1 && istype(loc, /turf/simulated) ? "h" : "" ]out"
 			else

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -42,7 +42,7 @@
 			src.broadcast_status()
 
 	update_icon()
-		if(node && on && !(stat & (NOPOWER|BROKEN)))
+		if(NODE_1 && on && !(stat & (NOPOWER|BROKEN)))
 			if(scrubbing)
 				icon_state = "[level == 1 && istype(loc, /turf/simulated) ? "h" : "" ]on"
 			else
@@ -98,7 +98,7 @@
 		..()
 		if(stat & (NOPOWER|BROKEN))
 			return
-		if (!node)
+		if (!NODE_1)
 			on = 0
 		//broadcast_status()
 		if(!on)

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -4,6 +4,7 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging
 	icon_state = "intact"
 	level = 2
 	var/initialize_directions_he
+	nodecount = 2
 
 	minimum_temperature_difference = 20
 	thermal_conductivity = WINDOW_HEAT_TRANSFER_COEFFICIENT
@@ -13,7 +14,7 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging
 		..()
 		initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 	// BubbleWrap END
-
+/*
 	initialize()
 		normalize_dir()
 		var/node1_dir
@@ -36,7 +37,7 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging
 				break
 		update_icon()
 		return
-
+*/
 
 	process()
 		if(!parent)
@@ -83,15 +84,16 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
 	// BubbleWrap END
 
 	update_icon()
-		if(node1&&node2)
+		if(NODE_1&&NODE_2)
 			icon_state = "intact"
 		else
-			var/have_node1 = node1?1:0
-			var/have_node2 = node2?1:0
+			var/have_node1 = NODE_1?1:0
+			var/have_node2 = NODE_2?1:0
 			icon_state = "exposed[have_node1][have_node2]"
-		if(!node1&&!node2)
+		if(!NODE_1&&!NODE_2)
 			qdel(src)
 		color = pipe_color
+/*
 
 	initialize()
 		for(var/obj/machinery/atmospherics/target in get_step(src,initialize_directions))
@@ -105,3 +107,4 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
 
 		update_icon()
 		return
+*/

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -1,5 +1,4 @@
 obj/machinery/atmospherics/pipe
-
 	var/datum/gas_mixture/air_temporary //used when reconstructing a pipeline that broke
 	var/datum/pipeline/parent
 
@@ -15,7 +14,10 @@ obj/machinery/atmospherics/pipe
 		//minimum pressure before check_pressure(...) should be called
 
 	proc/pipeline_expansion()
-		return null
+		if (node.len)
+			return node
+		else
+			return null
 
 	proc/check_pressure(pressure)
 		//Return 1 if parent should continue checking other pipes
@@ -53,11 +55,45 @@ obj/machinery/atmospherics/pipe
 
 	Destroy()
 		del(parent)
+
 		if(air_temporary)
 			loc.assume_air(air_temporary)
 			del(air_temporary)
 
+		for(NODE_LOOP)
+			if(!NODE_I) continue
+			var/obj/machinery/atmospherics/pipe/P = NODE_I
+			P.disconnect(src)
+
 		..()
+
+	disconnect(obj/machinery/atmospherics/reference)
+		for (NODE_LOOP)
+			if(reference == NODE_I)
+				if(istype(NODE_I, /obj/machinery/atmospherics/pipe))
+					del(parent)
+					NODE_I = null
+		update_icon()
+		return null
+
+	initialize()
+		normalize_dir()
+		var/list/node_dir = list(1=null,2=null,3=null,4=null)
+		for (var/direction in cardinal)
+			if(direction&initialize_directions)
+				for(var/I=1; I <= nodecount; I++)
+					if(!node_dir[I])
+						node_dir[I] = direction
+						break
+		for(NODE_LOOP)
+			for(var/obj/machinery/atmospherics/target in get_step(src,node_dir[I]))
+				if(target.initialize_directions & get_dir(target, src))
+					node[I] = target
+					break
+		var/turf/T = src.loc
+		if(T)
+			hide(T.intact)
+		update_icon()
 
 	simple
 		icon = 'icons/obj/pipes.dmi'
@@ -70,9 +106,13 @@ obj/machinery/atmospherics/pipe
 
 		dir = SOUTH
 		initialize_directions = SOUTH|NORTH
-
+		nodecount = 2
+		/*
 		var/obj/machinery/atmospherics/node1
 		var/obj/machinery/atmospherics/node2
+		*/
+
+
 
 		var/minimum_temperature_difference = 300
 		var/thermal_conductivity = 0 //WALL_HEAT_TRANSFER_COEFFICIENT No
@@ -168,52 +208,37 @@ obj/machinery/atmospherics/pipe
 			smoke.set_up(1,0, src.loc, 0)
 			smoke.start()
 			qdel(src)
-
+/*
 		proc/normalize_dir()
 			if(dir==3)
 				dir = 1
 			else if(dir==12)
 				dir = 4
-
+*/
+/*
 		Destroy()
-			if(node1)
-				node1.disconnect(src)
-			if(node2)
-				node2.disconnect(src)
+			if(node[1])
+				node[1].disconnect(src)
+			if(node[2])
+				node[2].disconnect(src)
 
 			..()
 
 		pipeline_expansion()
-			return list(node1, node2)
-
+			return node
+*/
 		update_icon()
-			if(node1&&node2)
-				/*
-				var/C = ""
-				switch(pipe_color)
-					if ("red") C = "-r"
-					if ("blue") C = "-b"
-					if ("cyan") C = "-c"
-					if ("green") C = "-g"
-					if ("yellow") C = "-y"
-					if ("purple") C = "-p"
-				*/
+			if(NODE_1&&NODE_2)
 				icon_state = "intact[invisibility ? "-f" : "" ]"
-
-				//var/node1_direction = get_dir(src, node1)
-				//var/node2_direction = get_dir(src, node2)
-
-				//dir = node1_direction|node2_direction
-
 			else
-				if(!node1&&!node2)
+				if(!NODE_1&&!NODE_2)
 					qdel(src) //TODO: silent deleting looks weird
-				var/have_node1 = node1?1:0
-				var/have_node2 = node2?1:0
+				var/have_node1 = NODE_1?1:0
+				var/have_node2 = NODE_2?1:0
 				icon_state = "exposed[have_node1][have_node2][invisibility ? "-f" : "" ]"
 			color = pipe_color
 
-
+/*
 		initialize()
 			normalize_dir()
 			var/node1_dir
@@ -228,11 +253,11 @@ obj/machinery/atmospherics/pipe
 
 			for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
 				if(target.initialize_directions & get_dir(target,src))
-					node1 = target
+					node[1] = target
 					break
 			for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
 				if(target.initialize_directions & get_dir(target,src))
-					node2 = target
+					node[2] = target
 					break
 
 
@@ -241,22 +266,17 @@ obj/machinery/atmospherics/pipe
 				hide(T.intact)
 			update_icon()
 			//update_icon()
-
+			*/
+/*
 		disconnect(obj/machinery/atmospherics/reference)
-			if(reference == node1)
-				if(istype(node1, /obj/machinery/atmospherics/pipe))
-					del(parent)
-				node1 = null
-
-			if(reference == node2)
-				if(istype(node2, /obj/machinery/atmospherics/pipe))
-					del(parent)
-				node2 = null
-
+			for (var/I = 1; I <= nodecount; I++)
+				if(reference == node[I])
+					if(istype(node[I], /obj/machinery/atmospherics/pipe))
+						del(parent)
+					node[I] = null
 			update_icon()
-
 			return null
-
+*/
 	simple/scrubbers
 		name="Scrubbers pipe"
 		pipe_color="red"
@@ -352,7 +372,7 @@ obj/machinery/atmospherics/pipe
 
 		can_unwrench = 0
 
-		var/obj/machinery/atmospherics/node1
+		nodecount = 1
 
 		New()
 			initialize_directions = dir
@@ -451,26 +471,27 @@ obj/machinery/atmospherics/pipe
 				air_temporary.nitrogen = (25*ONE_ATMOSPHERE*N2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature)
 
 				..()
-
+/*
 		Destroy()
 			if(node1)
 				node1.disconnect(src)
 
 			..()
-
+*/
+/*
 		pipeline_expansion()
-			return list(node1)
-
+			return list(node)
+*/
 		update_icon()
-			if(node1)
+			if(NODE_1)
 				icon_state = "intact"
 
-				dir = get_dir(src, node1)
+				dir = get_dir(src, NODE_1)
 
 			else
 				icon_state = "exposed"
 			color = pipe_color
-
+/*
 		initialize()
 
 			var/connect_direction = dir
@@ -491,7 +512,7 @@ obj/machinery/atmospherics/pipe
 			update_icon()
 
 			return null
-
+*/
 		attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 			if (istype(W, /obj/item/device/analyzer) && get_dist(user, src) <= 1)
 				atmosanalyzer_scan(parent.air, user)
@@ -594,10 +615,7 @@ obj/machinery/atmospherics/pipe
 
 		dir = SOUTH
 		initialize_directions = EAST|NORTH|WEST
-
-		var/obj/machinery/atmospherics/node1
-		var/obj/machinery/atmospherics/node2
-		var/obj/machinery/atmospherics/node3
+		nodecount = 3
 
 		level = 1
 		layer = 2.4 //under wires with their 2.44
@@ -621,10 +639,10 @@ obj/machinery/atmospherics/pipe
 			if(level == 1 && istype(loc, /turf/simulated))
 				invisibility = i ? 101 : 0
 			update_icon()
-
+/*
 		pipeline_expansion()
 			return list(node1, node2, node3)
-
+*/
 		process()
 			if(!parent)
 				..()
@@ -649,6 +667,7 @@ obj/machinery/atmospherics/pipe
 			else if (nodealert)
 				nodealert = 0
 */
+/*
 		Destroy()
 			if(node1)
 				node1.disconnect(src)
@@ -658,7 +677,8 @@ obj/machinery/atmospherics/pipe
 				node3.disconnect(src)
 
 			..()
-
+*/
+/*
 		disconnect(obj/machinery/atmospherics/reference)
 			if(reference == node1)
 				if(istype(node1, /obj/machinery/atmospherics/pipe))
@@ -678,19 +698,10 @@ obj/machinery/atmospherics/pipe
 			update_icon()
 
 			..()
+*/
 
 		update_icon()
-			if(node1&&node2&&node3)
-				/*
-				var/C = ""
-				switch(pipe_color)
-					if ("red") C = "-r"
-					if ("blue") C = "-b"
-					if ("cyan") C = "-c"
-					if ("green") C = "-g"
-					if ("yellow") C = "-y"
-					if ("purple") C = "-p"
-				*/
+			if(NODE_1 && NODE_2 && NODE_3)
 				icon_state = "manifold[invisibility ? "-f" : ""]"
 
 			else
@@ -698,12 +709,17 @@ obj/machinery/atmospherics/pipe
 				var/unconnected = 0
 				var/connect_directions = (NORTH|SOUTH|EAST|WEST)&(~dir)
 
+				for(NODE_LOOP)
+					if(NODE_I)
+						connected |= get_dir(src, NODE_I)
+				/*
 				if(node1)
-					connected |= get_dir(src, node1)
+					connected |= get_dir(src, NODE_1)
 				if(node2)
 					connected |= get_dir(src, node2)
 				if(node3)
 					connected |= get_dir(src, node3)
+				*/
 
 				unconnected = (~connected)&(connect_directions)
 
@@ -713,7 +729,7 @@ obj/machinery/atmospherics/pipe
 					qdel(src)
 			color = pipe_color
 			return
-
+/*
 		initialize()
 			var/connect_directions = (NORTH|SOUTH|EAST|WEST)&(~dir)
 
@@ -754,7 +770,7 @@ obj/machinery/atmospherics/pipe
 				hide(T.intact)
 			//update_icon()
 			update_icon()
-
+*/
 	manifold/scrubbers
 		name="Scrubbers pipe"
 		pipe_color="red"

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -107,3 +107,15 @@
 #define PRESSURE_SUIT_REDUCTION_COEFFICIENT 0.8		//This is how much (percentual) a suit with the flag STOPSPRESSUREDMAGE reduces pressure.
 #define PRESSURE_HEAD_REDUCTION_COEFFICIENT 0.4		//This is how much (percentual) a helmet/hat with the flag STOPSPRESSUREDMAGE reduces pressure.
 
+//Atmos Pipe stuff. Taking a hint from TG here.
+
+ //Standardized for loop.
+#define NODE_LOOP 							var/I = 1; I <= nodecount; I++
+
+//Standardized node references
+#define NODE_I 								node[I]
+#define NODE_1								node[1]
+#define NODE_2								node[2]
+#define NODE_3								node[3]
+#define NODE_4								node[4]
+

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -112,28 +112,14 @@ datum/controller/game_controller/proc/setup_engineering()
 		for(var/turf/simulated/wall/wall in world)
 			wall.relativewall() // Reconnect all walls moved
 
-		for(var/obj/machinery/atmospherics/pipe/simple/M in world)
-			M.initialize()
-			M.build_network() //Re-attach all the now moved atmos pipes.
-			if(M.node1)
-				M.node1.initialize()
-				M.node1.build_network()
-			if(M.node2)
-				M.node2.initialize()
-				M.node2.build_network()
+		for(var/obj/machinery/atmospherics/pipe/P in world)
+			P.initialize()
+			P.build_network() // Force re-connect all atmos pipes.
+			for(var/I; I <= P.nodecount; I++)
+				var/obj/machinery/atmospherics/pipe/M = P.node[I]
+				M.initialize()
+				M.build_network()
 
-		for(var/obj/machinery/atmospherics/pipe/manifold/M in world)
-			M.initialize()
-			M.build_network() //Re-attach all the now moved atmos pipes.
-			if(M.node1)
-				M.node1.initialize()
-				M.node1.build_network()
-			if(M.node2)
-				M.node2.initialize()
-				M.node2.build_network()
-			if(M.node3)
-				M.node3.initialize()
-				M.node3.build_network()
 
 		for(var/B in typesof(/area/engine/alternate))
 			var/template = locate(B)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -258,6 +258,81 @@ Buildable meters
 
 	var/pipefailtext = "\red There's nothing to connect this pipe section to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 
+	var/pipe_path
+
+	//Identify which pipe path to spawn
+	switch(pipe_type)
+		if(PIPE_SIMPLE_STRAIGHT, PIPE_SIMPLE_BENT)
+			pipe_path = /obj/machinery/atmospherics/pipe/simple
+		if(PIPE_HE_STRAIGHT, PIPE_HE_BENT)
+			pipe_path = /obj/machinery/atmospherics/pipe/simple/heat_exchanging
+		if(PIPE_CONNECTOR)
+			pipe_path = /obj/machinery/atmospherics/portables_connector
+		if(PIPE_MANIFOLD)
+			pipe_path = /obj/machinery/atmospherics/pipe/manifold
+			pipefailtext = "\red There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
+		if(PIPE_JUNCTION)
+			pipe_path = /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
+			pipefailtext = "\red There's nothing to connect this junction to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
+		if(PIPE_UVENT)
+			pipe_path = /obj/machinery/atmospherics/unary/vent_pump
+		if(PIPE_MVALVE)
+			pipe_path = /obj/machinery/atmospherics/valve
+		if(PIPE_DVALVE)
+			pipe_path = /obj/machinery/atmospherics/valve/digital
+		if(PIPE_PUMP)
+			pipe_path = /obj/machinery/atmospherics/binary/pump
+		if(PIPE_GAS_FILTER)
+			pipe_path = /obj/machinery/atmospherics/trinary/filter
+		if(PIPE_GAS_MIXER)
+			pipe_path = /obj/machinery/atmospherics/trinary/mixer
+		if(PIPE_SCRUBBER)
+			pipe_path = /obj/machinery/atmospherics/unary/vent_scrubber
+		if(PIPE_INSULATED_STRAIGHT, PIPE_INSULATED_BENT)
+			pipe_path = /obj/machinery/atmospherics/pipe/simple/insulated
+		if(PIPE_PASSIVE_GATE)
+			pipe_path = /obj/machinery/atmospherics/binary/passive_gate
+		if(PIPE_VOLUME_PUMP)
+			pipe_path = /obj/machinery/atmospherics/binary/volume_pump
+		if(PIPE_HEAT_EXCHANGE)
+			pipe_path = /obj/machinery/atmospherics/unary/heat_exchanger
+	//Spawn it
+	var/obj/machinery/atmospherics/A = new pipe_path(get_turf(src))
+	//Initialize variables
+	A.dir = dir
+	A.initialize_directions = pipe_dir
+	A.pipe_color = pipe_color
+	//Check if pipe should be on the floor or the underfloor
+	if(pipe_type != (PIPE_HE_STRAIGHT || PIPE_HE_BENT || PIPE_JUNCTION)) //Listed pipe types do not check if turf is intact.
+		var/turf/T = get_turf(src)
+		A.level = T.intact ? 2 : 1
+	//If it's not a plain pipe, allow name setting
+	if(pipe_type != (PIPE_SIMPLE_STRAIGHT || PIPE_SIMPLE_BENT || PIPE_HE_STRAIGHT || PIPE_HE_BENT || PIPE_MANIFOLD || PIPE_JUNCTION || PIPE_INSULATED_STRAIGHT || PIPE_INSULATED_BENT)) //It was actually easier to list pipes DIDN'T set the pipename
+		if(pipename)
+			A.name = pipename
+	//Initialize the pipe
+	A.initialize()
+	if(!A)
+		//If the pipe was deleted, alert the user
+		usr << pipefailtext
+		return 1
+	A.build_network()
+	//Force re-initialization of connected pipes. All atmos machinery now has a list node[] containing nodecount nodes.
+	for(var/I = 1; I <= A.nodecount; I++)
+		var/obj/machinery/atmospherics/B = A.node[I]
+		if(!B) continue
+		B.initialize()
+		B.build_network()
+
+	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+	user.visible_message( \
+		"[user] fastens the [src].", \
+		"\blue You have fastened the [src].", \
+		"You hear ratchet.")
+	qdel(src)	// remove the pipe item
+
+	return
+/*
 	switch(pipe_type)
 		if(PIPE_SIMPLE_STRAIGHT, PIPE_SIMPLE_BENT)
 			var/obj/machinery/atmospherics/pipe/simple/P = new( src.loc )
@@ -271,12 +346,12 @@ Buildable meters
 				usr << pipefailtext
 				return 1
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_HE_STRAIGHT, PIPE_HE_BENT)
 			var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/P = new ( src.loc )
@@ -291,12 +366,12 @@ Buildable meters
 				usr << pipefailtext
 				return 1
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_CONNECTOR)		// connector
 			var/obj/machinery/atmospherics/portables_connector/C = new( src.loc )
@@ -309,9 +384,9 @@ Buildable meters
 			C.level = T.intact ? 2 : 1
 			C.initialize()
 			C.build_network()
-			if (C.node)
-				C.node.initialize()
-				C.node.build_network()
+			if (C.NODE_1)
+				C.NODE_1:initialize()
+				C.NODE_1:build_network()
 
 
 		if(PIPE_MANIFOLD)		//manifold
@@ -327,15 +402,15 @@ Buildable meters
 				usr << "There's nothing to connect this manifold to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			M.build_network()
-			if (M.node1)
-				M.node1.initialize()
-				M.node1.build_network()
-			if (M.node2)
-				M.node2.initialize()
-				M.node2.build_network()
-			if (M.node3)
-				M.node3.initialize()
-				M.node3.build_network()
+			if (M.NODE_1)
+				M.NODE_1:initialize()
+				M.NODE_!.build_network()
+			if (M.NODE_2)
+				M.NODE_2:initialize()
+				M.NODE_2:build_network()
+			if (M.NODE_3)
+				M.NODE_3:initialize()
+				M.NODE_3:build_network()
 
 		if(PIPE_JUNCTION)
 			var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/P = new ( src.loc )
@@ -350,12 +425,12 @@ Buildable meters
 				usr << "There's nothing to connect this junction to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)"
 				return 1
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_UVENT)		//unary vent
 			var/obj/machinery/atmospherics/unary/vent_pump/V = new( src.loc )
@@ -368,9 +443,9 @@ Buildable meters
 			V.level = T.intact ? 2 : 1
 			V.initialize()
 			V.build_network()
-			if (V.node)
-				V.node.initialize()
-				V.node.build_network()
+			if (V.NODE_1)
+				V.NODE_1:initialize()
+				V.NODE_1:build_network()
 
 
 		if(PIPE_MVALVE)		//manual valve
@@ -384,14 +459,14 @@ Buildable meters
 			V.level = T.intact ? 2 : 1
 			V.initialize()
 			V.build_network()
-			if (V.node1)
-//					world << "[V.node1.name] is connected to valve, forcing it to update its nodes."
-				V.node1.initialize()
-				V.node1.build_network()
-			if (V.node2)
-//					world << "[V.node2.name] is connected to valve, forcing it to update its nodes."
-				V.node2.initialize()
-				V.node2.build_network()
+			if (V.NODE_1)
+//					world << "[V.NODE_1:name] is connected to valve, forcing it to update its nodes."
+				V.NODE_1:initialize()
+				V.NODE_1:build_network()
+			if (V.NODE_2)
+//					world << "[V.NODE_2:name] is connected to valve, forcing it to update its nodes."
+				V.NODE_2:initialize()
+				V.NODE_2:build_network()
 
 		if(PIPE_DVALVE) //Digital valves. Shameless copypaste from manual valves because I don't into atmos code.
 			var/obj/machinery/atmospherics/valve/digital/V = new(src.loc)
@@ -404,12 +479,12 @@ Buildable meters
 			V.level = T.intact ? 2 : 1
 			V.initialize()
 			V.build_network()
-			if (V.node1)
-				V.node1.initialize()
-				V.node1.build_network()
-			if (V.node2)
-				V.node2.initialize()
-				V.node2.build_network()
+			if (V.NODE_1)
+				V.NODE_1:initialize()
+				V.NODE_1:build_network()
+			if (V.NODE_2)
+				V.NODE_2:initialize()
+				V.NODE_2:build_network()
 
 		if(PIPE_PUMP)		//gas pump
 			var/obj/machinery/atmospherics/binary/pump/P = new(src.loc)
@@ -422,12 +497,12 @@ Buildable meters
 			P.level = T.intact ? 2 : 1
 			P.initialize()
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_GAS_FILTER)		//gas filter
 			var/obj/machinery/atmospherics/trinary/filter/P = new(src.loc)
@@ -440,15 +515,15 @@ Buildable meters
 			P.level = T.intact ? 2 : 1
 			P.initialize()
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
-			if (P.node3)
-				P.node3.initialize()
-				P.node3.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
+			if (P.NODE_3)
+				P.NODE_3:initialize()
+				P.NODE_3:build_network()
 
 		if(PIPE_GAS_MIXER)		//gas filter
 			var/obj/machinery/atmospherics/trinary/mixer/P = new(src.loc)
@@ -461,15 +536,15 @@ Buildable meters
 			P.level = T.intact ? 2 : 1
 			P.initialize()
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
-			if (P.node3)
-				P.node3.initialize()
-				P.node3.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
+			if (P.NODE_3)
+				P.NODE_3:initialize()
+				P.NODE_3:build_network()
 
 		if(PIPE_SCRUBBER)		//scrubber
 			var/obj/machinery/atmospherics/unary/vent_scrubber/S = new(src.loc)
@@ -482,9 +557,9 @@ Buildable meters
 			S.level = T.intact ? 2 : 1
 			S.initialize()
 			S.build_network()
-			if (S.node)
-				S.node.initialize()
-				S.node.build_network()
+			if (S.NODE_1)
+				S.NODE_1:initialize()
+				S.NODE_1:build_network()
 
 		if(PIPE_INSULATED_STRAIGHT, PIPE_INSULATED_BENT)
 			var/obj/machinery/atmospherics/pipe/simple/insulated/P = new( src.loc )
@@ -498,12 +573,12 @@ Buildable meters
 				usr << pipefailtext
 				return 1
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_PASSIVE_GATE)		//passive gate
 			var/obj/machinery/atmospherics/binary/passive_gate/P = new(src.loc)
@@ -516,12 +591,12 @@ Buildable meters
 			P.level = T.intact ? 2 : 1
 			P.initialize()
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_VOLUME_PUMP)		//volume pump
 			var/obj/machinery/atmospherics/binary/volume_pump/P = new(src.loc)
@@ -534,12 +609,12 @@ Buildable meters
 			P.level = T.intact ? 2 : 1
 			P.initialize()
 			P.build_network()
-			if (P.node1)
-				P.node1.initialize()
-				P.node1.build_network()
-			if (P.node2)
-				P.node2.initialize()
-				P.node2.build_network()
+			if (P.NODE_1)
+				P.NODE_1:initialize()
+				P.NODE_1:build_network()
+			if (P.NODE_2)
+				P.NODE_2:initialize()
+				P.NODE_2:build_network()
 
 		if(PIPE_HEAT_EXCHANGE)		// heat exchanger
 			var/obj/machinery/atmospherics/unary/heat_exchanger/C = new( src.loc )
@@ -552,9 +627,9 @@ Buildable meters
 			C.level = T.intact ? 2 : 1
 			C.initialize()
 			C.build_network()
-			if (C.node)
-				C.node.initialize()
-				C.node.build_network()
+			if (C.NODE_1)
+				C.NODE_1:initialize()
+				C.NODE_1:build_network()
 
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 	user.visible_message( \
@@ -564,6 +639,7 @@ Buildable meters
 	qdel(src)	// remove the pipe item
 
 	return
+*/
 	 //TODO: DEFERRED
 
 // ensure that setterm() is called for a newly connected pipeline

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -13,12 +13,12 @@
 
 	//Manifolds
 	for (var/obj/machinery/atmospherics/pipe/manifold/pipe in world)
-		if (!pipe.node1 || !pipe.node2 || !pipe.node3)
+		if (!pipe.NODE_1 || !pipe.NODE_2 || !pipe.NODE_3)
 			usr << "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])"
 
 	//Pipes
 	for (var/obj/machinery/atmospherics/pipe/simple/pipe in world)
-		if (!pipe.node1 || !pipe.node2)
+		if (!pipe.NODE_1 || !pipe.NODE_2)
 			usr << "Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])"
 
 /client/proc/powerdebug()


### PR DESCRIPTION
-Changes all atmos machinery to use node list instead of individual vars
-Standardized several functions that were identically defined for every individual pipe and machine
-Cleaned up the pipe construction code

Current changes focus on quality of life improvements for anyone wishing to modify or add on to the pipe code.