### PR TITLE
EMP symptom fix

### DIFF
--- a/code/datums/diseases/advance/symptoms/emp.dm
+++ b/code/datums/diseases/advance/symptoms/emp.dm
@@ -26,8 +26,8 @@ BONUS
 
 /datum/symptom/emp/Activate(var/datum/disease/advance/A)
 	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+	var/mob/living/M = A.affected_mob
+	if(prob(SYMPTOM_ACTIVATION_PROB) && !M.stat)
 		M << "<span class='notice'>You discharge.</span>"
 		switch(A.stage)
 			if(1,2)


### PR DESCRIPTION
Prevents dead infected mobs from becoming EMP generators.