### PR TITLE
Implemented pipe and pipeline renaming

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -68,7 +68,51 @@ obj/machinery/atmospherics/update_icon()
 	color = pipe_color
 	return null
 
+obj/machinery/atmospherics/proc/rename(var/newname, var/pipe)
+	if(newname)
+		src.name = newname
+	else
+		src.name = initial(src.name)
+	if(pipe)
+		//typecast because i just want this all in one damned place.
+		var/obj/machinery/atmospherics/pipe/P = src
+		//force parent to exist
+		if(!P.parent)
+			P.parent = new /datum/pipeline()
+			P.parent.build_pipeline(src)
+		if(P.parent.naming_pipe)
+			return 0
+		//if no name entered, reset.
+		if(newname == "")
+			P.parent.resetname()
+		else
+			P.parent.naming_pipe = P
+		//build_pipeline propagates the new name.
+		P.parent.build_pipeline(src)
+	return 1
+
+
+
 obj/machinery/atmospherics/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
+
+	if(istype(W, /obj/item/weapon/pen))
+		var/newname = stripped_input(user,"Enter a name. Leave blank for default.","Rename",src.name) //Sanitize sanitize sanitize
+		var/ispipe
+		if (istype(src, /obj/machinery/atmospherics/pipe))
+			ispipe = 1
+		else
+			ispipe = 0
+		if(istype(src, /obj/machinery/atmospherics/unary/vent_pump) || istype(src, /obj/machinery/atmospherics/unary/vent_scrubber))
+			user << "You cannot name this machine!"
+			return 1
+		//user << "You begin to rename the pipe.."
+		//Flavo threatened to call the police if i committed the comment that used to be here.
+		if(src.rename(newname, ispipe))
+			user << "You rename the pipe to [newname]."
+			return 1
+		else
+			user << "\red Someone is already naming this pipeline!" //Realistically? Chances of this are tiny
+			return 1
 
 	if(istype(W, /obj/item/weapon/pipe_painter))
 		var/obj/item/weapon/pipe_painter/P = W

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -8,6 +8,11 @@ datum/pipeline
 
 	var/alert_pressure = 0
 
+	//naming pipe doubles as a check to prevent asshats from trying to name the pipeline at the same time.
+	//pipeline_name holds that name to allow expansions to the pipeline to persist with the new name
+	var/obj/machinery/atmospherics/pipe/naming_pipe = null
+	var/pipeline_name
+
 	Del()
 		if(network)
 			del(network)
@@ -68,8 +73,16 @@ datum/pipeline
 		else
 			air = new
 
+		if(naming_pipe)
+			pipeline_name = naming_pipe.name
+
 		while(possible_expansions.len>0)
 			for(var/obj/machinery/atmospherics/pipe/borderline in possible_expansions)
+				//rename all pipes to the pipeline's name
+				if(pipeline_name)
+					borderline.name = pipeline_name
+				else
+					borderline.name = initial(borderline.name) // if no name, revert.
 
 				var/list/result = borderline.pipeline_expansion()
 				var/edge_check = result.len
@@ -95,6 +108,7 @@ datum/pipeline
 
 				possible_expansions -= borderline
 
+		naming_pipe = null
 		air.volume = volume
 
 	proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
@@ -192,3 +206,6 @@ datum/pipeline
 				air.temperature -= heat/total_heat_capacity
 		if(network)
 			network.update = 1
+
+	proc/resetname()
+		src.pipeline_name = null


### PR DESCRIPTION
-Adds ability to rename whole pipelines with the pen
-Adds ability to rename components individually
-Leaving the field blank will result in reversion to the default names for each pipe.
-Pipeline names will persist for all new pipes added to that pipeline after renaming.

Please keep an eye out for abuse. I have a couple ideas in mind to balance out potential abuses...