### PR TITLE
Instant crew transfer when there are 0 living players

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -144,7 +144,11 @@ datum/controller/vote
 			world.Reboot()
 
 		if(crew_transfer)
-			if(emergency_shuttle)
+			if(ticker) ticker.stalemate_check() // stalemate check
+			if(ticker && ticker.stalemate)
+				//if no living clients
+				if(emergency_shuttle) emergency_shuttle.location = 2
+			else if(emergency_shuttle)
 				emergency_shuttle.incall(1)
 				emergency_shuttle.prevent_recall = 1
 				priority_announce("The crew transfer shuttle is en route. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.", "Crew Transfer")
@@ -190,7 +194,7 @@ datum/controller/vote
 			var/sound/S = sound('sound/effects/alert.ogg',0,1,0)
 			for(var/mob/M in world)
 				M << S
-			var/text = "[capitalize(mode)] vote started by [initiator]."
+			var/text = "[capitalize(mode)] vote started[initiator ? " by [initiator]" : ""]."
 			if(mode == "custom")
 				text += "\n[question]"
 			log_vote(text)

--- a/code/game/gameticker.dm
+++ b/code/game/gameticker.dm
@@ -9,6 +9,7 @@ var/round_start_time = 0
 /datum/controller/gameticker
 	var/const/restart_timeout = 250
 	var/current_state = GAME_STATE_PREGAME
+	var/stalemate = 0 // 0: business as usual | 1: crew transfer votes will be instant
 
 	var/hide_mode = 0
 	var/datum/game_mode/mode = null
@@ -431,4 +432,12 @@ var/round_start_time = 0
 
 	logPerseusMissions()
 
+	return 1
+
+/datum/controller/gameticker/proc/stalemate_check()
+	for(var/mob/M in player_list)
+		if(M.stat != 2)
+			stalemate = 0
+			return 0
+	stalemate = 1
 	return 1

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -10,4 +10,5 @@
 	return
 
 /mob/proc/death(gibbed)
+	if(ticker) ticker.stalemate_check() // stalemate check
 	return

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -52,6 +52,8 @@
 		var/obj/Loc=loc
 		Loc.on_log()
 
+	if(ticker) ticker.stalemate_check() // stalemate check
+
 // Calling update_interface() in /mob/Login() causes the Cyborg to immediately be ghosted; because of winget().
 // Calling it in the overriden Login, such as /mob/living/Login() doesn't cause this.
 /mob/proc/update_interface()

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -34,4 +34,6 @@
 		var/obj/Loc=loc
 		Loc.on_log()
 
+	if(ticker) ticker.stalemate_check() // stalemate check
+
 	return 1


### PR DESCRIPTION
When there are no living players in the game world, crew transfer votes will instantly happen instead of waiting 10 minutes