### PR TITLE
Replace Create Object panel filtering logic

### DIFF
--- a/html/create_object.html
+++ b/html/create_object.html
@@ -27,7 +27,7 @@
 	<form name="spawner" action="byond://?src=/* ref src */" method="get">
 		<input type="hidden" name="src" value="/* ref src */">
 		
-		Type <input type="text" name="filter" value="" onkeyup="updateSearch()" onkeypress="submitFirst(event)" style="width:350px"><br>
+		Type <input type="text" name="filter" value="" style="width:280px"><input type="button" value="Search" onclick="updateSearch()"><br>
 		Offset: <input type="text" name="offset" value="x,y,z" style="width:250px">
 		
 		A <input type="radio" name="offset_type" value="absolute">
@@ -54,7 +54,6 @@
 		var objects = object_paths == null ? new Array() : object_paths.split(";");
 		
 		document.spawner.filter.focus();
-		populateList(objects);
 		
 		function populateList(from_list)
 		{


### PR DESCRIPTION
Changes the logic on the create object panel to use a search button instead of every typed letter. This prevents the freezing from occurring unless the search field is blank. Javascript by Falaskian.
Tested and confirmed.