### PR TITLE
Refactors atmospheric/singularity loops

### DIFF
--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -71,7 +71,7 @@
 		if(node[1])
 			var/obj/machinery/atmospherics/A = node[1]
 			A.disconnect(src)
-			del(network)
+			qdel(network)
 
 		node = null
 
@@ -123,7 +123,7 @@
 
 	disconnect(obj/machinery/atmospherics/reference)
 		if(reference==node[1])
-			del(network)
+			qdel(network)
 			node[1] = null
 
 		return null

--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -84,7 +84,8 @@
 		volume = affected.fuel_burnt*FIRE_GROWTH_RATE
 		location.assume_air(affected)
 
-	for(var/atom/item in loc)
+	for(var/X in loc)
+		var/atom/item = X
 		if(item && item != src) // It's possible that the item is deleted in temperature_expose
 			item.fire_act(null, temperature, volume)
 	return 0

--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -70,22 +70,46 @@ datum/controller/air_system
 	air_superconductivity = (world.timeofday - timer) / 10
 
 /datum/controller/air_system/proc/process_hotspots()
-	for(var/obj/effect/hotspot/H in hotspots)
-		H.process()
+	var/i=1
+	while(i<=hotspots.len)
+		var/obj/effect/hotspot/H = hotspots[i]
+		if(H)
+			H.process()
+			i++
+			continue
+		hotspots.Cut(i,i+1)
 
 /datum/controller/air_system/proc/process_super_conductivity()
-	for(var/turf/simulated/T in active_super_conductivity)
-		T.super_conduct()
+	var/i = 1
+	while(i<=active_super_conductivity.len)
+		var/turf/simulated/T = active_super_conductivity[i]
+		if(T)
+			T.super_conduct()
+			i++
+			continue
+		active_super_conductivity.Cut(i,i+1)
 
 /datum/controller/air_system/proc/process_high_pressure_delta()
-	for(var/turf/T in high_pressure_delta)
-		T.high_pressure_movements()
-		T.pressure_difference = 0
+	var/i = 1
+	while(i<=high_pressure_delta.len)
+		var/turf/T = high_pressure_delta[i]
+		if(T)
+			T.high_pressure_movements()
+			T.pressure_difference = 0
+			i++
+			continue
+		high_pressure_delta.Cut(i,i+1)
 	high_pressure_delta.len = 0
 
 /datum/controller/air_system/proc/process_active_turfs()
-	for(var/turf/simulated/T in active_turfs)
-		T.process_cell()
+	var/i = 1
+	while(i<=active_turfs.len)
+		var/turf/simulated/T = active_turfs[i]
+		if(T)
+			T.process_cell()
+			i++
+			continue
+		active_turfs.Cut(i,i+1)
 
 /datum/controller/air_system/proc/remove_from_active(var/turf/simulated/T)
 	if(istype(T))
@@ -130,13 +154,19 @@ datum/controller/air_system
 						active_turfs |= T
 
 /datum/controller/air_system/proc/process_excited_groups()
-	for(var/datum/excited_group/EG in excited_groups)
-		EG.breakdown_cooldown ++
-		if(EG.breakdown_cooldown == 10)
-			EG.self_breakdown()
-			return
-		if(EG.breakdown_cooldown > 20)
-			EG.dismantle()
+	var/i = 1
+	while(i<=excited_groups.len)
+		var/datum/excited_group/EG = excited_groups[i]
+		if(EG)
+			EG.breakdown_cooldown ++
+			if(EG.breakdown_cooldown == 10)
+				EG.self_breakdown()
+				return
+			if(EG.breakdown_cooldown > 20)
+				EG.dismantle()
+			i++
+			continue
+		excited_groups.Cut(i,i+1)
 
 /turf/proc/CanAtmosPass(var/turf/T)
 	if(!istype(T))	return 0

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -298,13 +298,15 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 /datum/excited_group/proc/merge_groups(var/datum/excited_group/E)
 	if(turf_list.len > E.turf_list.len)
 		air_master.excited_groups -= E
-		for(var/turf/simulated/T in E.turf_list)
+		for(var/X in E.turf_list)
+			var/turf/simulated/T = X
 			T.excited_group = src
 			turf_list += T
 			reset_cooldowns()
 	else
 		air_master.excited_groups -= src
-		for(var/turf/simulated/T in turf_list)
+		for(var/X in turf_list)
+			var/turf/simulated/T = X
 			T.excited_group = E
 			E.turf_list += T
 			E.reset_cooldowns()
@@ -314,11 +316,13 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 
 /datum/excited_group/proc/self_breakdown()
 	var/datum/gas_mixture/A = new
-	for(var/turf/simulated/T in turf_list)
+	for(var/X in turf_list)
+		var/turf/simulated/T = X
 		for (var/G in T.air.gasses)
 			A.add_gas(G, T.air.gasses[G])
 
-	for(var/turf/simulated/T in turf_list)
+	for(var/X in turf_list)
+		var/turf/simulated/T = X
 		for(var/G in A.gasses)
 			T.air.gasses[G] = A.gasses[G]/turf_list.len
 
@@ -327,7 +331,8 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 
 
 /datum/excited_group/proc/dismantle()
-	for(var/turf/simulated/T in turf_list)
+	for(var/X in turf_list)
+		var/turf/simulated/T = X
 		T.excited = 0
 		T.recently_active = 0
 		T.excited_group = null
@@ -335,7 +340,8 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	garbage_collect()
 
 /datum/excited_group/proc/garbage_collect()
-	for(var/turf/simulated/T in turf_list)
+	for(var/X in turf_list)
+		var/turf/simulated/T = X
 		T.excited_group = null
 	turf_list.Cut()
 	air_master.excited_groups -= src

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -212,7 +212,8 @@ var/global/list/uneatable = list(
 //	if(defer_powernet_rebuild != 2)
 //		defer_powernet_rebuild = 1
 	// Let's just make this one loop.
-	for(var/atom/X in orange(grav_pull,src))
+	var/list/L = orange(grav_pull,src)
+	for(var/atom/X in L)
 		var/dist = get_dist(X, src)
 		// Movable atoms only
 		if(dist > consume_range && istype(X, /atom/movable))


### PR DESCRIPTION
most foreach loops in atmospheric related code has been optimized for performance.

additionally modifies a foreach loop in singularity's eat() to improve performance

also fixes runtime that would occur when singularities ate atmospheric gear