### PR TITLE
Make Mob visible in Cryo

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -255,17 +255,32 @@
 /obj/machinery/atmospherics/unary/cryo_cell/update_icon()
 	if(panel_open)
 		icon_state = "cell-o"
+		overlays.Cut()
 		return
 	if(state_open)
 		icon_state = "cell-open"
+		overlays.Cut()
 		return
 	if(on)
 		if(occupant)
-			icon_state = "cell-occupied"
+			icon_state = "cell-on"
+			overlays.Cut()
+			var/image/O = image(occupant)
+			O.pixel_y = 24
+			O.layer = 4.05
+			overlays += O
+			var/image/I = new
+			I.icon = icon
+			I.icon_state = "cell-on"
+			I.layer = 4.1
+			I.alpha = 190
+			overlays += I
 		else
 			icon_state = "cell-on"
+			overlays.Cut()
 	else
 		icon_state = "cell-off"
+		overlays.Cut()
 
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/process_occupant()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -267,12 +267,12 @@
 			overlays.Cut()
 			var/image/O = image(occupant)
 			O.pixel_y = 24
-			O.layer = 4.05
+			O.layer = layer + 0.01
 			overlays += O
 			var/image/I = new
 			I.icon = icon
 			I.icon_state = "cell-on"
-			I.layer = 4.1
+			I.layer = layer + 0.02
 			I.alpha = 190
 			overlays += I
 		else


### PR DESCRIPTION
Changes the icon handling to make the mob inside of a cryotube visible. Removes the use for the cryo-occupied icon state.