### PR TITLE
Improve specificity of note timestamp

### DIFF
--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -78,7 +78,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	if(!notesfile)	return
 	notesfile.cd = "/[ckey]"
 	notesfile.eof = 1		//move to the end of the buffer
-	notesfile << "[time2text(world.realtime,"DD-MMM-YYYY")] | [note][(usr && usr.ckey)?" ~[usr.ckey]":""]"
+	notesfile << "[time2text(world.realtime,"DD-MMM-YYYY")] @ [time_stamp("hh:mm")] | [note][(usr && usr.ckey)?" ~[usr.ckey]":""]"
 
 	if(lognote)//don't need an admin log for the notes applied automatically during bans.
 		message_admins("[key_name(usr)] added note '[note]' to [ckey]")


### PR DESCRIPTION
Increase the specificity of the note timestamps to include the hour and minute in server time, this will allow us to locate logs much more quickly in the event of questions.